### PR TITLE
Migrate Dockerfile to CentOS 8 Stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM centos:7
+FROM quay.io/centos/centos:stream8
 
-RUN yum install -y lapack lapack-devel
+RUN dnf install --enablerepo powertools -y lapack lapack-devel dnf-plugins-core
 
 # Install necessary build tools
-RUN yum install -y gcc-c++ make swig3
-RUN yum install -y blas-devel
-RUN yum-config-manager --add-repo https://yum.repos.intel.com/mkl/setup/intel-mkl.repo
+RUN dnf install -y gcc-c++ make swig
+RUN dnf install -y blas-devel
+RUN dnf config-manager --add-repo https://yum.repos.intel.com/mkl/setup/intel-mkl.repo
 RUN rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
-RUN yum install -y intel-mkl-2019.3-062
-RUN yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel maven
-RUN yum install -y numpy
+RUN dnf install -y intel-mkl-2019.3-062
+RUN dnf install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel maven
+RUN dnf install -y python3-numpy
 
 ENV LD_LIBRARY_PATH=/opt/intel/mkl/lib/intel64:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH=/opt/intel/mkl/lib/intel64:$LIBRARY_PATH
@@ -31,6 +31,6 @@ RUN make install
 
 # Create source files
 WORKDIR /opt/JFaiss/jni
-RUN make 
+RUN make
 ENTRYPOINT [ "cp", "-r", "/opt/JFaiss/cpu/src/main", "/github/workspace/build" ]
 #&& tail -f /dev/null


### PR DESCRIPTION
* Regular CentOS 8 is not recommended anymore.
* dnf is now the standard package manager
* dnf-plugins-core allow for the config-manager.
* lapack-devel is now in powertools repo.
* swig3 is now just swig (still version 3)
* numpy is now python3-numpy