### PR TITLE
Fix Docker build: adjust CentOS repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:7
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-*.repo
+
 RUN yum install -y lapack lapack-devel
 
 # Install necessary build tools


### PR DESCRIPTION
Since CentOS reached EOL, mirrorlist.centos.org is not available. 

To be able to install packages, we should update repositories: 
- use "baseurl" instead of "mirrorlist";
- use "vault.centos.org" instead of "mirror.centos.org"

More details can be found here: https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve/1161847#1161847