### PR TITLE
Fix FAISS compilation from sources: add include path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV LD_PRELOAD=${LD_PRELOAD}:/opt/intel/mkl/lib/intel64/libmkl_gnu_thread.so
 COPY . /opt/JFaiss
 WORKDIR /opt/JFaiss/faiss
 
-ENV CXXFLAGS="-mavx2 -mf16c"
+ENV CXXFLAGS=${CXXFLAGS}" -mavx2 -mf16c -I/opt/JFaiss"
 # Install faiss
 RUN ./configure --prefix=/usr --without-cuda
 RUN make -j $(nproc)


### PR DESCRIPTION
Add current directory to the include path when compiling FAISS from sources.

N.B. In FAISS v1.6.4 the directory structure is reorganized and this fix won't be needed.

GitHub: #3