### PR TITLE
Build Faiss with AVX2 support and remove unused dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,10 @@ RUN yum install -y intel-mkl-2019.3-062
 RUN yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel maven
 RUN yum install -y numpy
 
-ENV LD_LIBRARY_PATH=/opt/intel/mkl/lib/intel64:$LD_LIBRARY_PATH
-ENV LIBRARY_PATH=/opt/intel/mkl/lib/intel64:$LIBRARY_PATH
-ENV LD_PRELOAD=${LD_PRELOAD}:/usr/lib64/libgomp.so.1
-ENV LD_PRELOAD=${LD_PRELOAD}:/opt/intel/mkl/lib/intel64/libmkl_def.so
-ENV LD_PRELOAD=${LD_PRELOAD}:/opt/intel/mkl/lib/intel64/libmkl_avx2.so
-ENV LD_PRELOAD=${LD_PRELOAD}:/opt/intel/mkl/lib/intel64/libmkl_core.so
-ENV LD_PRELOAD=${LD_PRELOAD}:/opt/intel/mkl/lib/intel64/libmkl_intel_lp64.so
-ENV LD_PRELOAD=${LD_PRELOAD}:/opt/intel/mkl/lib/intel64/libmkl_gnu_thread.so
+ENV MKL_ROOT=/opt/intel/mkl/lib/intel64
+
+ENV LD_LIBRARY_PATH=$MKL_ROOT:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH=$MKL_ROOT:$LIBRARY_PATH
 
 COPY . /opt/JFaiss
 WORKDIR /opt/JFaiss/faiss

--- a/jni/Makefile
+++ b/jni/Makefile
@@ -29,20 +29,17 @@ swigfaiss_avx2.cpp: swigfaiss.swig ../faiss/libfaiss.a
 
 # Extension is .so even on OSX.
 _%.so: %.o ../faiss/libfaiss.a
-	$(CXX) $(SHAREDFLAGS) $(LDFLAGS) -Wl,--export-dynamic,-rpath='$$ORIGIN' -o $@ $^ $(LIBS) -lmkl_def
+	$(CXX) $(SHAREDFLAGS) $(LDFLAGS) -Wl,--export-dynamic,-rpath='$$ORIGIN' -o $@ $^ $(LIBS)
 	chmod 755 $@
 
-build: _swigfaiss.so 
+build: _swigfaiss_avx2.so
 	$(eval _resources_path = ../cpu/src/main/resources)
 	mkdir -p ${_resources_path}
-	cp _swigfaiss.so ${_resources_path}
-	#cp _swigfaiss_avx2.so ${_resources_path}
+	cp _swigfaiss_avx2.so ${_resources_path}
 	cp /usr/lib64/libgomp.so.1 ${_resources_path}
-	cp /opt/intel/mkl/lib/intel64/libmkl_def.so ${_resources_path}
-	cp /opt/intel/mkl/lib/intel64/libmkl_avx2.so ${_resources_path}
-	cp /opt/intel/mkl/lib/intel64/libmkl_core.so ${_resources_path}
-	cp /opt/intel/mkl/lib/intel64/libmkl_intel_lp64.so ${_resources_path}
-	cp /opt/intel/mkl/lib/intel64/libmkl_gnu_thread.so ${_resources_path}
+	cp $(MKL_ROOT)/libmkl_core.so ${_resources_path}
+	cp $(MKL_ROOT)/libmkl_intel_lp64.so ${_resources_path}
+	cp $(MKL_ROOT)/libmkl_gnu_thread.so ${_resources_path}
 
 
 clean:

--- a/src/main/java/com/vectorsearch/faiss/utils/JFaissConstants.java
+++ b/src/main/java/com/vectorsearch/faiss/utils/JFaissConstants.java
@@ -5,12 +5,10 @@ import java.util.List;
 
 public class JFaissConstants {
     public static final List<String> SUPPORTED_OS = Collections.singletonList("Linux");
-    public static final String SWIGFAISS_SO_FILE = "/_swigfaiss.so";
+    public static final String SWIGFAISS_SO_FILE = "/_swigfaiss_avx2.so";
     public static final String[] REQUIRED_SO_FILE = new String[]{
             "/libgomp.so.1",
             "/libmkl_core.so",
-            "/libmkl_avx2.so",
-            "/libmkl_def.so",
             "/libmkl_gnu_thread.so",
             "/libmkl_intel_lp64.so"};
 }


### PR DESCRIPTION
Last build of `jfaiss-cpu` failed to load 2 dependencies:
```
Failed loading/tmp/nativeutils2616849860630264/libmkl_avx2.so
/tmp/nativeutils2616849860630264/libmkl_avx2.so: undefined symbol: mkl_sparse_optimize_bsr_trsm_i8
Failed loading/tmp/nativeutils2616849860630264/libmkl_def.so
/tmp/nativeutils2616849860630264/libmkl_def.so: undefined symbol: mkl_sparse_optimize_bsr_trsm_i8
```

However, despite this the library worked correctly.

This is because those 2 libraries are not actually needed, despite they are listed in the dependencies. We can just remove the linker flags that add those libraries and the library would work.

Also, in this change we've build Faiss with AVX2 support.