### PR TITLE
Build faiss without AVX2

### DIFF
--- a/jni/Makefile
+++ b/jni/Makefile
@@ -32,10 +32,10 @@ _%.so: %.o ../faiss/libfaiss.a
 	$(CXX) $(SHAREDFLAGS) $(LDFLAGS) -Wl,--export-dynamic,-rpath='$$ORIGIN' -o $@ $^ $(LIBS)
 	chmod 755 $@
 
-build: _swigfaiss_avx2.so
+build: _swigfaiss.so
 	$(eval _resources_path = ../cpu/src/main/resources)
 	mkdir -p ${_resources_path}
-	cp _swigfaiss_avx2.so ${_resources_path}
+	cp _swigfaiss.so ${_resources_path}
 	cp /usr/lib64/libgomp.so.1 ${_resources_path}
 	cp $(MKL_ROOT)/libmkl_core.so ${_resources_path}
 	cp $(MKL_ROOT)/libmkl_intel_lp64.so ${_resources_path}

--- a/src/main/java/com/vectorsearch/faiss/utils/JFaissConstants.java
+++ b/src/main/java/com/vectorsearch/faiss/utils/JFaissConstants.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public class JFaissConstants {
     public static final List<String> SUPPORTED_OS = Collections.singletonList("Linux");
-    public static final String SWIGFAISS_SO_FILE = "/_swigfaiss_avx2.so";
+    public static final String SWIGFAISS_SO_FILE = "/_swigfaiss.so";
     public static final String[] REQUIRED_SO_FILE = new String[]{
             "/libgomp.so.1",
             "/libmkl_core.so",


### PR DESCRIPTION
It seems that *_avx2 version technically doesn't have any difference, but it just changes the module name.